### PR TITLE
Fix label 'Genotype' being wrong

### DIFF
--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -71,7 +71,7 @@ export default {
       cascadeSelected: [],
       numberShown: 10,
       filters: [],
-      facets: ['Species', 'Gender', 'Genotype'],
+      facets: ['Species', 'Gender', 'Organ'],
       numberDatasetsShown: ["10", "20", "50"],
       props: { multiple: true },
       options: [{


### PR DESCRIPTION
Note that this unfortunately requires sparc-api changes which are [here](https://github.com/ABI-Software/sparc-api/pull/17)

(Sparc-api changes should be implemented first as they are non-breaking)