### PR TITLE
Updated the way to detect a simulation dataset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/map-side-bar",
-  "version": "1.1.14",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/SidebarContent.vue
+++ b/src/components/SidebarContent.vue
@@ -284,9 +284,7 @@ export default {
           id: id,
           scaffolds: element['abi-scaffold-metadata-file'] ? element['abi-scaffold-metadata-file'] : undefined,
           contextualInformation: element['abi-contextual-information'].length > 0 ? element['abi-contextual-information'] : undefined,
-          simulation: element.additionalLinks
-            ? element.additionalLinks[0].description == 'Repository'
-            : false,
+          simulation: element['abi-simulation-file'],
         });
         id++;
 

--- a/src/components/SidebarContent.vue
+++ b/src/components/SidebarContent.vue
@@ -276,7 +276,7 @@ export default {
           organs: (element.organs && element.organs.length > 0)
               ? [...new Set(element.organs.map(v => v.name))]
               : undefined,
-          species: element.organisms 
+          species: element.organisms
             ? element.organisms[0].species
               ? [...new Set(element.organisms.map((v) =>v.species ? v.species.name : null))]
               : undefined


### PR DESCRIPTION
Until now, we relied on the additional links information, but now we should rely on `abi-simulation-file` being present or not.