### PR TITLE
Context card source fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/map-side-bar",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "main": "./dist/map-side-bar.common.js",
   "files": [
     "dist/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/map-side-bar",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "main": "./dist/map-side-bar.common.js",
   "files": [
     "dist/*",

--- a/src/components/ContextCard.vue
+++ b/src/components/ContextCard.vue
@@ -79,9 +79,13 @@ Vue.use(Button);
 Vue.use(Select);
 Vue.use(Input);
 
-// const addFilesToPath = function(path){
-//   return 'files/' + path
-// }
+const addFilesToPathIfMissing = function(path){
+  if (!path.includes('files')){
+    return 'files/' + path
+  } else {
+    return path
+  }
+}
 
 const convertBackslashToForwardSlash = function(path){
   path = path.replaceAll('\\','/')
@@ -89,11 +93,11 @@ const convertBackslashToForwardSlash = function(path){
   return path
 }
 
-const switchPathToDirectory = function(path){
-  let newPath = path.split('/')
-  newPath.pop()
-  return newPath.join('/')
-}
+// const switchPathToDirectory = function(path){
+//   let newPath = path.split('/')
+//   newPath.pop()
+//   return newPath.join('/')
+// }
 
 
 export default {
@@ -230,17 +234,15 @@ export default {
       })
     },
     processPathForUrl(path){
-      console.log(path)
-      window.path = path
       path = convertBackslashToForwardSlash(path)
-      path = switchPathToDirectory(path)
+      path = addFilesToPathIfMissing(path)
       return encodeURI(path)
     },
     splitDoiFromUrl(url){
       return url.split('https://doi.org/').pop()
     },
     generateFileLink(sample){
-      return `https://sparc.science/datasets/${sample.discoverId}?datasetDetailsTab=files&path=${this.processPathForUrl(sample.path)}`
+      return `https://sparc.science/file/${sample.discoverId}/${sample.version}?path=${this.processPathForUrl(sample.path)}`
 
     },
     openViewFile: function(view){

--- a/src/components/ContextCard.vue
+++ b/src/components/ContextCard.vue
@@ -79,9 +79,9 @@ Vue.use(Button);
 Vue.use(Select);
 Vue.use(Input);
 
-const addFilesToPath = function(path){
-  return 'files/' + path
-}
+// const addFilesToPath = function(path){
+//   return 'files/' + path
+// }
 
 const convertBackslashToForwardSlash = function(path){
   path = path.replaceAll('\\','/')
@@ -234,7 +234,6 @@ export default {
       window.path = path
       path = convertBackslashToForwardSlash(path)
       path = switchPathToDirectory(path)
-      path = addFilesToPath(path)
       return encodeURI(path)
     },
     splitDoiFromUrl(url){

--- a/src/components/ContextCard.vue
+++ b/src/components/ContextCard.vue
@@ -284,7 +284,7 @@ export default {
 
 .view-image {
   width: 34px;
-  height: auto;
+  height: 34px;
   flex: 1;
   margin-right: 4px;
 }

--- a/src/components/SidebarContent.vue
+++ b/src/components/SidebarContent.vue
@@ -1,7 +1,7 @@
 <template>
   <el-card :body-style="bodyStyle" class="content-card">
     <div slot="header" class="header">
-      <context-card v-if="contextCardEntry && contextCardEnabled" :entry="contextCardEntry" />
+      <context-card v-if="contextCardEntry && contextCardEnabled" :entry="contextCardEntry" :envVars="envVars"/>
       <el-input
         class="search-input"
         placeholder="Search"


### PR DESCRIPTION
New feature:
- Add ability to have a source of a view or sample be of a separate dataset 

Bug fixes:
- Switch 'source' in context cards back to the files page (ie https://sparc.science/file/34/5?path=files%2Fderivative%2Fstim_proximal-colon_manometry.csv )
- Fix view icons sizing issue when there are long descriptions (was stretching the image)
- Add more checks for processing the source file paths in context card (some have 'files' prefix, some use backslashes)