### PR TITLE
Context card banners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abi-software/map-side-bar",
-  "version": "1.3.24",
+  "version": "1.3.25",
   "main": "./dist/map-side-bar.common.js",
   "files": [
     "dist/*",

--- a/src/components/ContextCard.vue
+++ b/src/components/ContextCard.vue
@@ -5,7 +5,7 @@
       <div v-show="!showDetails" class="hide" @click="showDetails = !showDetails">Show information<i class="el-icon-arrow-down"></i></div>
       <el-card v-if="showDetails && Object.keys(contextData).length !== 0" v-loading="loading" class="context-card" >
         <div class="card-left">
-          <img :src="entry.banner" class="context-image">
+          <img :src="banner" class="context-image">
         </div>
         <div class="card-right scrollbar">
           <div class="title">{{contextData.heading}}</div>
@@ -158,6 +158,16 @@ export default {
       }
       else return false
     },
+    banner: function(){
+      if (this.contextData.banner){
+        this.getFileFromPath(this.contextData.banner) 
+      } else if (this.contextData && this.contextData.views) {
+        if(this.contextData.views[0].thumbnail){
+          return this.getFileFromPath(this.contextData.views[0].thumbnail)
+        }
+      } 
+      return this.entry.banner
+    }
   },
   methods: {
     samplesMatching: function(viewId){


### PR DESCRIPTION
[Now use first view as banner](https://github.com/Tehsurfer/map-sidebar/commit/a197d7cd2577c21c5460d06ef4f7988806555855) 

 - Also added a banner field which can be controlled from the context
   card by putting an image path there
 - if there is no banner field or view thumbnail, the dataest banner
   will be used
   
   