### PR TITLE
Check resources data to show component

### DIFF
--- a/src/components/ConnectivityInfo.vue
+++ b/src/components/ConnectivityInfo.vue
@@ -18,7 +18,7 @@
         <div class="block" v-else>
           <div class="title">{{ entry.featureId }}</div>
         </div>
-        <external-resource-card :resources="resources"></external-resource-card>
+        <external-resource-card v-if="resources.length" :resources="resources"></external-resource-card>
       </div>
       <div>
         <el-popover


### PR DESCRIPTION
## Improvement

To load `<external-resource-card>` component only if there is data. 