### PR TITLE
Externalise utilities when bundling.

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -38,11 +38,12 @@ export default defineConfig({
             fileName: 'map-side-bar',
         },
         rollupOptions: {
-            external: ["vue"],
+            external: ["vue", "@abi-software/map-utilities"],
             output: {
-                globals: {
-                    vue: "Vue",
-                },
+              globals: {
+                vue: "Vue",
+                "@abi-software/map-utilities": "@abi-software/map-utilities"
+              },
             },
         },
     },


### PR DESCRIPTION
Sidebar package size reduces from 1716.50kB to 768.33 kB.
map-viewer size reduces from 8281.77kB to 7607.70kB