### PR TITLE
Change the way to get the list of biolucida images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@element-plus/icons-vue": "^2.3.1",
         "algoliasearch": "^4.10.5",
         "element-plus": "2.8.4",
+        "js-base64": "^3.7.7",
         "marked": "^4.1.1",
         "mitt": "^3.0.1",
         "unplugin-vue-components": "^0.26.0",
@@ -4143,6 +4144,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
     },
     "node_modules/js-stringify": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@element-plus/icons-vue": "^2.3.1",
     "algoliasearch": "^4.10.5",
     "element-plus": "2.8.4",
+    "js-base64": "^3.7.7",
     "marked": "^4.1.1",
     "mitt": "^3.0.1",
     "unplugin-vue-components": "^0.26.0",

--- a/src/components/DatasetCard.vue
+++ b/src/components/DatasetCard.vue
@@ -264,7 +264,8 @@ export default {
           // The encoded string is in the following format -
           // ${image_id}-col-${collection_id}, collection id can be any valid collection id
           // and 260 is used for now.
-          const share_link = encodeURIComponent(Base64.encode(`${image_id}-col-260`));
+          const code = encodeURIComponent(Base64.encode(`${image_id}-col-260`));
+          const share_link = `https://sparc.biolucida.net/image?c=${code}`
           dataset_images.push({
             share_link,
             image_id,

--- a/src/components/DatasetCard.vue
+++ b/src/components/DatasetCard.vue
@@ -256,7 +256,7 @@ export default {
       const dataset_images = [];
       const biolucida2DItems = 'biolucida-2d' in this.entry ? this.entry['biolucida-2d'] :[];
       const biolucida3DItems = 'biolucida-3d' in this.entry ? this.entry['biolucida-3d'] :[];
-      // We use information form SciCrunch to create the sharelink
+      // We use information from SciCrunch to create the sharelink
       biolucida2DItems.concat(biolucida3DItems).forEach((bObject) => {
         const image_id = bObject.biolucida?.identifier;
         if (image_id) {

--- a/src/components/DatasetCard.vue
+++ b/src/components/DatasetCard.vue
@@ -256,14 +256,14 @@ export default {
       const dataset_images = [];
       const biolucida2DItems = 'biolucida-2d' in this.entry ? this.entry['biolucida-2d'] :[];
       const biolucida3DItems = 'biolucida-3d' in this.entry ? this.entry['biolucida-3d'] :[];
-      // Images need to exist in both Scicrunch and Biolucida
+      // We use information form SciCrunch to create the sharelink
       biolucida2DItems.concat(biolucida3DItems).forEach((bObject) => {
         const image_id = bObject.biolucida?.identifier;
         if (image_id) {
           const sourcepkg_id = 'identifier' in bObject ? bObject['identifier'] : "";
           // The encoded string is in the following format -
           // ${image_id}-col-${collection_id}, collection id can be any valid collection id
-          // and we using 260 for now.
+          // and 260 is used for now.
           const share_link = encodeURIComponent(Base64.encode(`${image_id}-col-260`));
           dataset_images.push({
             share_link,

--- a/src/components/ImageGallery.vue
+++ b/src/components/ImageGallery.vue
@@ -33,7 +33,7 @@ import GalleryHelper from '@abi-software/gallery/src/mixins/GalleryHelpers.js'
 import Gallery from "@abi-software/gallery";
 import "@abi-software/gallery/dist/style.css";
 //provide the s3Bucket related methods and data.
-import S3Bucket from '../mixins/S3Bucket.vue'
+import S3Bucket from '../mixins/S3Bucket.vue';
 
 export default {
   name: 'ImageGallery',


### PR DESCRIPTION
This update will change the way list of Biolucida images is created. Instead of getting the sharelink from the dataset search api on Biolucida, we use the information from SciCrunch exclusively. This will avoid some potential issues in the future curation pipeline,