### PR TITLE
Fix connectivity graph render on data change

### DIFF
--- a/src/components/ConnectivityInfo.vue
+++ b/src/components/ConnectivityInfo.vue
@@ -209,6 +209,7 @@
     <div class="content-container" v-show="activeView === 'graphView'">
       <template v-if="graphViewLoaded">
         <connectivity-graph
+          :key="entry.featureId[0]"
           :entry="entry.featureId[0]"
           :mapServer="envVars.FLATMAPAPI_LOCATION"
           :sckanVersion="sckanVersion"


### PR DESCRIPTION
### Bug

The connectivity graph is not reloading with new data when different connectivity is selected.

On staging, select connectivity and view the connectivity graph. Select different connectivity on the map without closing the existing graph. The graph should be loaded with updated data, but it does not.

### Fix

Adding `:key` in the `connectivity-graph` component to refresh the component when data changes.
