### PR TITLE
Fix SidebarContent component loading twice

### DIFF
--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -42,7 +42,7 @@
                 @connectivity-component-click="onConnectivityComponentClick"
               />
             </template>
-            <template v-else-if="tab.type === 'annotation'">
+            <template v-if="tab.type === 'annotation'">
               <annotation-tool
                 :ref="'annotationTab_' + tab.id"
                 v-show="tab.id === activeTabId"
@@ -54,7 +54,7 @@
                 @confirm-delete="$emit('confirm-delete', $event)"
               />
             </template>
-            <template v-else>
+            <template v-if="tab.type === 'search'">
               <SidebarContent
                 class="sidebar-content-container"
                 v-show="tab.id === activeTabId"


### PR DESCRIPTION
The `SidebarContent` component is loading twice because of `if-else` logic.
This causes double API calls for Algolia.
