### PR TITLE
Fix copyClipboard content refresh

### DIFF
--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -32,6 +32,7 @@
             <!-- Connectivity Info -->
             <template v-if="tab.type === 'connectivity' && connectivityInfo">
               <connectivity-info
+                :key="connectivityInfo.title"
                 :entry="connectivityInfo"
                 :availableAnatomyFacets="availableAnatomyFacets"
                 v-if="tab.id === activeTabId"


### PR DESCRIPTION
The connectivity info component should be refreshed when switching from display search. 

### Steps to reproduce the bug

1. Open the connectivity tab by clicking a neuron path or using display search.
2. Click copy to clipboard, and it will copy the currently opened connectivity data.
3. Open another connectivity using display search without closing the active connectivity tab.
4. Click copy to clipboard, and it still remains the previous data.