### PR TITLE
Fix connectivity max height

### DIFF
--- a/src/components/ConnectivityExplorer.vue
+++ b/src/components/ConnectivityExplorer.vue
@@ -475,7 +475,7 @@ export default {
   }
 
   &.is-active {
-    max-height: 1800px;
+    max-height: 9999px;
     background-color: #f7faff;
     border: 2px solid $app-primary-color;
     border-radius: var(--el-border-radius-base);


### PR DESCRIPTION
Some items in connectivity have a box height taller, and the card overlaps with another card when opened.

Example **kblad 6**

![image](https://github.com/user-attachments/assets/7e94a5cc-9bbc-4fe1-a935-5f43d4a8176d)
