### PR TITLE
Fix search issue after clicking reset button

### DIFF
--- a/src/components/ConnectivityExplorer.vue
+++ b/src/components/ConnectivityExplorer.vue
@@ -301,6 +301,9 @@ export default {
           if (option.withSearch) {
             this.searchKnowledge(this.filter, search);
           }
+          if (filter.length === 0) {
+            this.filters = this.filter;
+          }
           this.$refs.filtersRef.setCascader(this.filter);
         }
       } else {

--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -488,13 +488,6 @@ export default {
             }
           })
 
-        // if all checkboxes are checked
-        // there has no filter values
-        const filtersLength = filters.filter((item) => item.facet !== 'Show all');
-        if (!filtersLength.length) {
-          filters = [];
-        }
-
         // timeout: add delay for filter checkboxes
         if (this.filterTimeout) {
           clearTimeout(this.filterTimeout);

--- a/src/components/SearchHistory.vue
+++ b/src/components/SearchHistory.vue
@@ -215,24 +215,12 @@ export default {
       }
       return 0;
     },
-    formatFilters(filterItem) {
-      // because filters do not work correctly with facet2
-      if (filterItem.facet2) {
-        filterItem.facet = filterItem.facet2;
-        delete filterItem.facet2;
-      }
-      return filterItem;
-    },
     addSearchToHistory(filters = [], search = '') {
       search = search.trim() // remove whitespace
 
       const isExistingItem = this.searchHistory.some((item) => {
         let historyFilters = item.filters;
         let newFilters = filters;
-
-        // make all filters same format
-        historyFilters.forEach((filter) => this.formatFilters(filter));
-        newFilters.forEach((filter) => this.formatFilters(filter));
 
         // sort filters (to check duplicates in string format)
         historyFilters = historyFilters.sort(this.sortFilters);
@@ -333,11 +321,6 @@ export default {
           item['longLabel'] = longLabel;
         }
 
-        // make all filters same format
-        item.filters.forEach((filter) =>
-          this.formatFilters(filter)
-        );
-
         // sort filters (to check duplicates in string format)
         item.filters = item.filters.sort(this.sortFilters);
 
@@ -372,7 +355,7 @@ export default {
 
       if (filters) {
         filterItems = filters.filter((filterItem) => filterItem.facet !== 'Show all');
-        filterLabels = filterItems.map((item) => item.facet2 || item.facet);
+        filterLabels = filterItems.map((item) => item.facet);
       }
 
       if (label && filterItems.length) {

--- a/src/components/SidebarContent.vue
+++ b/src/components/SidebarContent.vue
@@ -183,7 +183,7 @@ export default {
       this.results = []
       this.loadingCards = false
     },
-    openSearch: function (filter, search = '', option = { withSearch: true }) {
+    openSearch: function (filter, search = '') {
       this.searchInput = search
       this.resetPageNavigation()
       //Proceed normally if cascader is ready
@@ -202,9 +202,7 @@ export default {
           this.$refs.filtersRef.checkShowAllBoxes()
           this.resetSearch()
         } else if (this.filter) {
-          if (option.withSearch) {
-            this.searchAlgolia(this.filter, search)
-          }
+          this.searchAlgolia(this.filter, search)
           this.$refs.filtersRef.setCascader(this.filter)
           this.searchHistoryUpdate(this.filter, search);
         }
@@ -212,7 +210,7 @@ export default {
         //cascader is not ready, perform search if no filter is set,
         //otherwise waith for cascader to be ready
         this.filter = filter
-        if ((!filter || filter.length == 0) && option.withSearch) {
+        if (!filter || filter.length == 0) {
           this.searchAlgolia(this.filter, search)
           this.searchHistoryUpdate(this.filter, search);
         }
@@ -456,10 +454,8 @@ export default {
     },
     searchHistorySearch: function (item) {
       this.searchInput = item.search
-      this.searchAndFilterUpdate();
-      // withSearch: false to prevent algoliaSearch in openSearch
-      this.openSearch([...item.filters], item.search, { withSearch: false });
       this.filter = item.filters
+      this.openSearch([...item.filters], item.search);
     },
   },
   mounted: function () {

--- a/src/components/SidebarContent.vue
+++ b/src/components/SidebarContent.vue
@@ -255,34 +255,16 @@ export default {
         type: 'filter-update',
       })
     },
-    /**
-     * Transform filters for third level items to perform search
-     * because cascader keeps adding it back.
-     */
-    transformFiltersBeforeSearch: function (filters) {
-      return filters.map((filter) => {
-        if (filter.facet2) {
-          filter.facet = filter.facet2;
-          delete filter.facet2;
-        }
-        return filter;
-      });
-    },
     searchAndFilterUpdate: function () {
       this.resetPageNavigation();
-      const transformedFilters = this.transformFiltersBeforeSearch(this.filters);
-      this.searchAlgolia(transformedFilters, this.searchInput);
-      this.searchHistoryUpdate(this.filters, this.searchInput);
+      this.searchAlgolia(this.filter, this.searchInput);
+      this.searchHistoryUpdate(this.filter, this.searchInput);
     },
     searchHistoryUpdate: function (filters, search) {
       this.$refs.searchHistory.selectValue = 'Search history';
       // save history only if there has value
       if (filters.length || search?.trim()) {
-        const transformedFilters = this.transformFiltersBeforeSearch(filters);
-        this.$refs.searchHistory.addSearchToHistory(
-          transformedFilters,
-          search
-        );
+        this.$refs.searchHistory.addSearchToHistory(filters, search);
       }
     },
     searchAlgolia(filters, query = '') {

--- a/src/components/SidebarContent.vue
+++ b/src/components/SidebarContent.vue
@@ -104,7 +104,6 @@ var handleErrors = async function (response) {
 }
 
 var initial_state = {
-  filters: [],
   searchInput: '',
   lastSearch: '',
   results: [],
@@ -206,9 +205,6 @@ export default {
           if (option.withSearch) {
             this.searchAlgolia(this.filter, search)
           }
-          if (filter.length === 0) {
-            this.filters = this.filter
-          }
           this.$refs.filtersRef.setCascader(this.filter)
           this.searchHistoryUpdate(this.filter, search);
         }
@@ -252,7 +248,7 @@ export default {
       }
     },
     filterUpdate: function (filters) {
-      this.filters = [...filters]
+      this.filter = [...filters]
       this.searchAndFilterUpdate();
       this.$emit('search-changed', {
         value: filters,
@@ -330,7 +326,7 @@ export default {
       this.start = (page - 1) * this.numberPerPage
       this.page = page
       this.searchAlgolia(
-        this.filters,
+        this.filter,
         this.searchInput,
         this.numberPerPage,
         this.page
@@ -478,10 +474,10 @@ export default {
     },
     searchHistorySearch: function (item) {
       this.searchInput = item.search
-      this.filters = item.filters
       this.searchAndFilterUpdate();
       // withSearch: false to prevent algoliaSearch in openSearch
       this.openSearch([...item.filters], item.search, { withSearch: false });
+      this.filter = item.filters
     },
   },
   mounted: function () {

--- a/src/components/SidebarContent.vue
+++ b/src/components/SidebarContent.vue
@@ -206,6 +206,9 @@ export default {
           if (option.withSearch) {
             this.searchAlgolia(this.filter, search)
           }
+          if (filter.length === 0) {
+            this.filters = this.filter
+          }
           this.$refs.filtersRef.setCascader(this.filter)
           this.searchHistoryUpdate(this.filter, search);
         }
@@ -288,7 +291,6 @@ export default {
     },
     searchAlgolia(filters, query = '') {
       // Algolia search
-
       this.loadingCards = true
       this.algoliaClient
         .anatomyInSearch(getFilters(filters), query)


### PR DESCRIPTION
Because `searchAndFilterUpdate` relies on `this.filters`. Force update it if reset the explorer search.

This PR will focus on the changes to the dataset explorer. Because there is no filter for the connectivity explorer yet, related changes will be made in this [PR](https://github.com/ABI-Software/map-sidebar/pull/141).