### PR TITLE
Reset search when click on population

### DIFF
--- a/src/components/ConnectivityExplorer.vue
+++ b/src/components/ConnectivityExplorer.vue
@@ -210,7 +210,11 @@ export default {
     // watch for connectivityEntry changes
     // card should be expanded if there is only one entry and it is ready
     connectivityEntry: function (newVal, oldVal) {
-      if (newVal.length === 1 && newVal[0].ready) {
+      if (newVal.length > 0) {
+        this.$refs.filtersRef.checkShowAllBoxes();
+        this.searchInput = '';
+        this.filter = [];
+      } else if (newVal.length === 1 && newVal[0].ready) {
         // if the changed property is connectivity source, do not collapse
         if (
           (newVal[0].connectivitySource !== oldVal[0].connectivitySource) &&


### PR DESCRIPTION
Reset both query and facet search. Click brings up the clicked populations, but the search is a search on the whole connectivity knowledge. They are working separately.