### PR TITLE
Fix filter tag ui

### DIFF
--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -9,7 +9,7 @@
           closable
           @close="cascadeTagClose(presentTags[0])"
         >
-          <p class="tag-text">{{ presentTags[0] }}</p>
+          <span class="tag-text">{{ presentTags[0] }}</span>
         </el-tag>
         <el-popover
           v-if="presentTags.length > 1"
@@ -834,8 +834,8 @@ export default {
               result.push(validatedFilter)
               terms.push(validatedFilter.term)
             }
-          })         
-          // make sure unused filter terms' show all checkbox is always checked 
+          })
+          // make sure unused filter terms' show all checkbox is always checked
           this.options.forEach((option)=>{
             if (!terms.includes(option.label)) {
               result.push({
@@ -886,6 +886,7 @@ export default {
 }
 
 .tag-text {
+  display: block;
   max-width: 75px;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
The tags in filters have additional margin at the bottom on the portal integration. 

![image](https://github.com/user-attachments/assets/b135d3a4-092e-4be9-aaf0-cf82a0f360d1)
![image](https://github.com/user-attachments/assets/07b73e5f-a92a-40b3-96d6-f8bf69924ba2)

After the fix

![image](https://github.com/user-attachments/assets/39d8faac-33f2-4ef3-a3d7-a682daf9f386)
