### PR TITLE
Update highlights on the map when switching between connectivity explorer and annotation tabs

### DIFF
--- a/src/components/AnnotationTool.vue
+++ b/src/components/AnnotationTool.vue
@@ -12,7 +12,7 @@
       class="annotation-popup"
       :annotationEntry="annotationEntry"
       @annotation="$emit('annotation', $event)"
-      @hover-changed="$emit('hover-changed', $event)"
+      @hover-changed="onAnnotationPopupChanged"
     />
     <div v-if="createData && createData.toBeDeleted" class="delete-container">
       <el-row>
@@ -76,8 +76,18 @@ export default {
   data: function () {
     return {
       ElIconDelete: shallowRef(ElIconDelete),
+      annotationPopupData: null,
     };
   },
+  methods: {
+    onAnnotationPopupChanged: function (payload) {
+      this.annotationPopupData = payload;
+      this.emitHoverChanged();
+    },
+    emitHoverChanged: function () {
+      this.$emit('hover-changed', this.annotationPopupData);
+    },
+  }
 }
 </script>
 

--- a/src/components/AnnotationTool.vue
+++ b/src/components/AnnotationTool.vue
@@ -12,7 +12,7 @@
       class="annotation-popup"
       :annotationEntry="annotationEntry"
       @annotation="$emit('annotation', $event)"
-      @hover-changed="onAnnotationPopupChanged"
+      @hover-changed="$emit('hover-changed', $event)"
     />
     <div v-if="createData && createData.toBeDeleted" class="delete-container">
       <el-row>
@@ -79,15 +79,6 @@ export default {
       annotationPopupData: null,
     };
   },
-  methods: {
-    onAnnotationPopupChanged: function (payload) {
-      this.annotationPopupData = payload;
-      this.emitHoverChanged();
-    },
-    emitHoverChanged: function () {
-      this.$emit('hover-changed', this.annotationPopupData);
-    },
-  }
 }
 </script>
 

--- a/src/components/ConnectivityExplorer.vue
+++ b/src/components/ConnectivityExplorer.vue
@@ -2,7 +2,7 @@
   <el-card
     :body-style="bodyStyle"
     class="content-card"
-    @mouseleave="hoverChanged(undefined)"
+    @mouseleave="onHoverChanged($event, undefined)"
   >
     <template #header>
       <div class="header">
@@ -51,7 +51,7 @@
       class="content scrollbar"
       v-loading="loadingCards || initLoading"
       ref="content"
-      @mouseleave="hoverChanged(undefined)"
+      @mouseleave="onHoverChanged($event, undefined)"
     >
       <div class="error-feedback" v-if="results.length === 0 && !loadingCards">
         No results found - Please change your search / filter criteria.
@@ -61,7 +61,7 @@
         :key="result.id"
         :ref="'stepItem-'  + result.id"
         class="step-item"
-        @mouseenter="hoverChanged(result)"
+        @mouseenter="onHoverChanged($event, result)"
       >
         <ConnectivityCard
           v-show="expanded !== result.id"
@@ -260,6 +260,15 @@ export default {
         this.$nextTick(() => {
           this.$emit("connectivity-collapse-change", data);
         });
+      }
+    },
+    onHoverChanged: function (event, data) {
+      const { target } = event;
+
+      // mouseleave event won't trigger if the connectivity explorer tab is not in view
+      // e.g., switching to annotation tab on item click
+      if (data || (target && target.checkVisibility())) {
+        this.hoverChanged(data)
       }
     },
     hoverChanged: function (data) {

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -318,9 +318,16 @@ export default {
       const tabInfo = matchedTab.length ? matchedTab : this.tabEntries;
       this.activeTabId = tabInfo[0].id;
     },
+    highlightAnnotationItem: function (tab) {
+      const annotationTabs = this.$refs['annotationTab_' + tab.id];
+      if (tab.type === 'annotation' && annotationTabs && annotationTabs.length) {
+        annotationTabs[0].emitHoverChanged();
+      }
+    },
     tabClicked: function (tab) {
       this.setActiveTab(tab);
       this.$emit('tabClicked', tab);
+      this.highlightAnnotationItem(tab);
     },
     tabClosed: function (tab) {
       this.$emit('tabClosed', tab);

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -329,7 +329,7 @@ export default {
       this.activeTabId = tabInfo[0].id;
     },
     highlightActiveTabData: function (tab) {
-      let data;
+      let data = null;
 
       if (tab.type === 'connectivityExplorer') {
         data = this.activeConnectivityData;

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -177,6 +177,8 @@ export default {
       drawerOpen: false,
       availableAnatomyFacets: [],
       activeTabId: 1,
+      activeAnnotationData: null,
+      activeConnectivityData: null,
     }
   },
   methods: {
@@ -197,6 +199,14 @@ export default {
      */
     hoverChanged: function (id, data) {
       this.$emit('hover-changed', {...data,  tabId: id })
+
+      // save the last highlighted data for connectivity and annotation tabs
+      if (this.activeTabId === 2) {
+        this.activeConnectivityData = data;
+      }
+      if (this.activeTabId === 3) {
+        this.activeAnnotationData = data;
+      }
     },
     /**
      * This event is emitted when the show connectivity button is clicked.
@@ -318,16 +328,27 @@ export default {
       const tabInfo = matchedTab.length ? matchedTab : this.tabEntries;
       this.activeTabId = tabInfo[0].id;
     },
-    highlightAnnotationItem: function (tab) {
-      const annotationTabs = this.$refs['annotationTab_' + tab.id];
-      if (tab.type === 'annotation' && annotationTabs && annotationTabs.length) {
-        annotationTabs[0].emitHoverChanged();
+    highlightActiveTabData: function (tab) {
+      let data;
+
+      if (tab.type === 'connectivityExplorer') {
+        data = this.activeConnectivityData;
+      } else if (tab.type === 'annotation') {
+        data = this.activeAnnotationData;
+      } else {
+        // switching to dataset explorer tab will not highlight
+        // the highlight is from the last tab
+        // if needed, to update it here
+      }
+
+      if (data) {
+        this.$emit('hover-changed', {...data,  tabId: tab.id })
       }
     },
     tabClicked: function (tab) {
       this.setActiveTab(tab);
       this.$emit('tabClicked', tab);
-      this.highlightAnnotationItem(tab);
+      this.highlightActiveTabData(tab);
     },
     tabClosed: function (tab) {
       this.$emit('tabClosed', tab);

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -340,7 +340,14 @@ export default {
       let data = null;
 
       if (tab.type === 'connectivityExplorer') {
-        data = {...this.activeConnectivityData};
+        const connectivityExplorerTabRef = this.getTabRef(undefined, 'connectivityExplorer', true);
+        // check if any opened item
+        // if no opened item, highlight items will be based on the results in explorer
+        if (connectivityExplorerTabRef && !connectivityExplorerTabRef.expanded) {
+          data = { tabType: 'connectivity' };
+        } else {
+          data = {...this.activeConnectivityData};
+        }
       } else if (tab.type === 'annotation') {
         data = {...this.activeAnnotationData};
       } else {

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -177,8 +177,8 @@ export default {
       drawerOpen: false,
       availableAnatomyFacets: [],
       activeTabId: 1,
-      activeAnnotationData: null,
-      activeConnectivityData: null,
+      activeAnnotationData: { tabType: "annotation" },
+      activeConnectivityData: { tabType: "connectivity" },
     }
   },
   methods: {
@@ -200,11 +200,12 @@ export default {
     hoverChanged: function (id, data) {
       this.$emit('hover-changed', {...data,  tabId: id })
 
+      const activeTabType = this.getActiveTabTypeById(id);
       // save the last highlighted data for connectivity and annotation tabs
-      if (this.activeTabId === 2) {
+      if (activeTabType === 'connectivityExplorer') {
         this.activeConnectivityData = data;
       }
-      if (this.activeTabId === 3) {
+      if (activeTabType === 'annotation') {
         this.activeAnnotationData = data;
       }
     },
@@ -328,13 +329,20 @@ export default {
       const tabInfo = matchedTab.length ? matchedTab : this.tabEntries;
       this.activeTabId = tabInfo[0].id;
     },
+    getActiveTabTypeById: function (id) {
+      const foundTab = this.tabs.find((tab) => tab.id === id);
+      if (foundTab) {
+        return foundTab.type;
+      }
+      return '';
+    },
     highlightActiveTabData: function (tab) {
       let data = null;
 
       if (tab.type === 'connectivityExplorer') {
-        data = this.activeConnectivityData;
+        data = {...this.activeConnectivityData};
       } else if (tab.type === 'annotation') {
-        data = this.activeAnnotationData;
+        data = {...this.activeAnnotationData};
       } else {
         // switching to dataset explorer tab will not highlight
         // the highlight is from the last tab


### PR DESCRIPTION
### Added the following fixes

1. Clicking prev and next buttons in annotation tab highlights the relative paths on the map.
2. Switching between connectivity explorer and annotation tabs will update the highlights on the map based on the data from the opened tab.
