### PR TITLE
Add connectivity info in graph viewer open

### DIFF
--- a/src/components/ConnectivityInfo.vue
+++ b/src/components/ConnectivityInfo.vue
@@ -591,6 +591,7 @@ export default {
           ...this.destinationsWithDatasets,
           ...this.originsWithDatasets,
         ],
+        connectivityInfo: this.entry,
       };
       EventBus.emit('show-connectivity-graph', payload);
     },


### PR DESCRIPTION
This is a part of the connectivity graph viewer hover fix.

- https://github.com/ABI-Software/mapintegratedvuer/pull/493