### PR TITLE
Fix missing dataset thumbnails for different data

### DIFF
--- a/src/components/DatasetCard.vue
+++ b/src/components/DatasetCard.vue
@@ -187,22 +187,22 @@ export default {
       this.currentCategory = name
     },
     createSciCurnchItems: function () {
-      if (this.entry.detailsReady) {
+      this.createDatasetItem()
+      if (this.entry.s3uri) {
         this.updateS3Bucket(this.entry.s3uri)
-        this.createDatasetItem()
-        this.createFlatmapItems()
-        this.createScaffoldItems()
-        this.createSimulationItems()
-        this.createPlotItems()
       }
+      this.createFlatmapItems()
+      this.createScaffoldItems()
+      this.createSimulationItems()
+      this.createPlotItems()
       /* Disable these two
       this.createImageItems();
       this.createVideoItems();
       */
     },
     createDatasetItem: function () {
-      const link = `${this.envVars.ROOT_URL}/datasets/${this.discoverId}?type=dataset`
-      if (this.thumbnail) {
+      if (this.discoverId && this.thumbnail) {
+        const link = `${this.envVars.ROOT_URL}/datasets/${this.discoverId}?type=dataset`
         this.items['Dataset'].push({
           id: -1,
           //Work around gallery requires a truthy string


### PR DESCRIPTION
The condition check for `this.entry.detailsReady` is not working for datasets with fewer records.
This fixes the missing thumbnails for those datasets with less data.

---

However, those dataset cards still lack data, such as contributors. They are from Algolia's response, as shown below.

The screenshot below is from the response of Algolia dataset search's second page: the first 3 items have missing data, and the other 7 have all data.

<img width="541" height="273" alt="image" src="https://github.com/user-attachments/assets/f1b41f09-fa1a-4855-b24a-6eaed72f92d3" />

---

The screenshot below compares the missing data and all data from two datasets.

<img width="551" height="692" alt="image" src="https://github.com/user-attachments/assets/f093c17a-8701-4046-aaf8-af4aa8b82c40" />
